### PR TITLE
Expose cookieAttributes property

### DIFF
--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -8,6 +8,7 @@ import {
   CustomCategories,
   DefaultDestinationBehavior
 } from '../types'
+import { CookieAttributes } from 'js-cookie'
 
 function getNewDestinations(destinations: Destination[], preferences: CategoryPreferences) {
   const newDestinations: Destination[] = []
@@ -35,6 +36,7 @@ interface Props {
 
   cookieDomain?: string
   cookieName?: string
+  cookieAttributes?: CookieAttributes
 
   /**
    * Number of days until the preferences cookie should expire
@@ -275,6 +277,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       cookieDomain,
       cookieName,
       cookieExpires,
+      cookieAttributes,
       mapCustomPreferences,
       defaultDestinationBehavior
     } = this.props
@@ -319,7 +322,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
           customPreferences,
           cookieDomain,
           cookieName,
-          cookieExpires
+          cookieExpires,
+          cookieAttributes
         })
         conditionallyLoadAnalytics({
           writeKey,

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -1,5 +1,5 @@
 // TODO: remove duplicate cookie library from bundle
-import cookies from 'js-cookie'
+import cookies, { CookieAttributes } from 'js-cookie'
 import topDomain from '@segment/top-domain'
 import { WindowWithAJS, Preferences, CategoryPreferences } from '../types'
 import { EventEmitter } from 'events'
@@ -32,6 +32,7 @@ type SavePreferences = Preferences & {
   cookieDomain?: string
   cookieName?: string
   cookieExpires?: number
+  cookieAttributes?: CookieAttributes
 }
 
 const emitter = new EventEmitter()
@@ -52,7 +53,8 @@ export function savePreferences({
   customPreferences,
   cookieDomain,
   cookieName,
-  cookieExpires
+  cookieExpires,
+  cookieAttributes = {}
 }: SavePreferences) {
   const wd = window as WindowWithAJS
   if (wd.analytics) {
@@ -72,7 +74,8 @@ export function savePreferences({
 
   cookies.set(cookieName || DEFAULT_COOKIE_NAME, value, {
     expires,
-    domain
+    domain,
+    ...cookieAttributes
   })
 
   emitter.emit('preferencesSaved', {

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -78,6 +78,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     cookieDomain: undefined,
     cookieName: undefined,
     cookieExpires: undefined,
+    cookieAttributes: {},
     customCategories: undefined,
     bannerActionsBlock: undefined,
     bannerHideCloseButton: false,
@@ -99,6 +100,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       cookieDomain,
       cookieName,
       cookieExpires,
+      cookieAttributes,
       bannerContent,
       bannerActionsBlock,
       bannerSubContent,
@@ -126,6 +128,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         cookieDomain={cookieDomain}
         cookieName={cookieName}
         cookieExpires={cookieExpires}
+        cookieAttributes={cookieAttributes}
         initialPreferences={this.getInitialPreferences()}
         mapCustomPreferences={this.handleMapCustomPreferences}
         customCategories={customCategories}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { CloseBehavior, CloseBehaviorFunction } from './consent-manager/container'
 import { PreferencesManager } from './consent-manager-builder/preferences'
+import { CookieAttributes } from 'js-cookie'
 
 type AJS = SegmentAnalytics.AnalyticsJS & {
   initialized: boolean
@@ -111,6 +112,7 @@ export interface ConsentManagerProps {
   implyConsentOnInteraction?: boolean
   cookieDomain?: string
   cookieName?: string
+  cookieAttributes?: CookieAttributes
   cookieExpires?: number
   bannerContent: React.ReactNode
   bannerSubContent?: string

--- a/stories/0.3-consent-manager-custom-cookie-attributes.stories.tsx
+++ b/stories/0.3-consent-manager-custom-cookie-attributes.stories.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import cookies, { CookieAttributes } from 'js-cookie'
+import { Pane, Heading, Button } from 'evergreen-ui'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
+import { storiesOf } from '@storybook/react'
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
+import CookieView from './components/CookieView'
+
+const bannerContent = (
+  <span>
+    We use cookies (and other similar technologies) to collect data to improve your experience on
+    our site. By using our website, you’re agreeing to the collection of data as described in our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </span>
+)
+const bannerSubContent = 'You can manage your preferences here!'
+const preferencesDialogTitle = 'Website Data Collection Preferences'
+const preferencesDialogContent = (
+  <div>
+    <p>
+      Segment uses data collected by cookies and JavaScript libraries to improve your browsing
+      experience, analyze site traffic, deliver personalized advertisements, and increase the
+      overall performance of our site.
+    </p>
+    <p>
+      By using our website, you’re agreeing to our{' '}
+      <a
+        href="https://segment.com/docs/legal/website-data-collection-policy/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website Data Collection Policy
+      </a>
+      .
+    </p>
+    <p>
+      The table below outlines how we use this data by category. To opt out of a category of data
+      collection, select “No” and save your preferences.
+    </p>
+  </div>
+)
+const cancelDialogTitle = 'Are you sure you want to cancel?'
+const cancelDialogContent = (
+  <div>
+    Your preferences have not been saved. By continuing to use our website, you’re agreeing to our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </div>
+)
+
+const ConsentManagerExample = (props: { cookieAttributes: CookieAttributes }) => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
+  return (
+    <Pane>
+      <ConsentManager
+        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
+        otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        cancelDialogTitle={cancelDialogTitle}
+        cancelDialogContent={cancelDialogContent}
+        cookieAttributes={props.cookieAttributes}
+      />
+
+      <Pane marginX={100} marginTop={20}>
+        <Heading> Your website content </Heading>
+        <Pane display="flex">
+          <iframe
+            src="https://giphy.com/embed/JIX9t2j0ZTN9S"
+            width="480"
+            height="480"
+            frameBorder="0"
+          />
+
+          <iframe
+            src="https://giphy.com/embed/yFQ0ywscgobJK"
+            width="398"
+            height="480"
+            frameBorder="0"
+          />
+        </Pane>
+
+        <p>
+          <div>
+            <Heading>Current Preferences</Heading>
+            <SyntaxHighlighter language="json" style={docco}>
+              {JSON.stringify(prefs, null, 2)}
+            </SyntaxHighlighter>
+          </div>
+          <Button marginRight={20} onClick={openConsentManager}>
+            Change Cookie Preferences
+          </Button>
+          <Button
+            onClick={() => {
+              cookies.remove('tracking-preferences')
+              window.location.reload()
+            }}
+          >
+            Clear
+          </Button>
+        </p>
+      </Pane>
+      <CookieView />
+    </Pane>
+  )
+}
+
+storiesOf('React Component / Custom Cookie Attributes', module).add(
+  `Custom Cookie Attributes`,
+  () => <ConsentManagerExample cookieAttributes={{ sameSite: 'none', secure: true }} />
+)


### PR DESCRIPTION
### Changes
- Exposed a cookieAttributes property in order to allow customization of the tracking preferences cookie. Our use case is to be able to set the `secure` and `sameSite` attributes in order to enable the consent manager in embedded apps.

### Jira Items
[HYBRID-1153](https://officernd.atlassian.net/browse/HYBRID-1138)